### PR TITLE
export NODE_OPTIONS

### DIFF
--- a/templates/etc.default.kibana.j2
+++ b/templates/etc.default.kibana.j2
@@ -4,7 +4,7 @@ chroot="{{ kibana_chroot_path }}"
 chdir="{{ kibana_chdir }}"
 nice="{{ kibana_nice }}"
 
-NODE_OPTIONS="--max-old-space-size={{ kibana_max_old_space_size }}"
+export NODE_OPTIONS="--max-old-space-size={{ kibana_max_old_space_size }}"
 
 {% if kibana_major_version >= 5 %}
 # If this is set to 1, then when `stop` is called, if the process has


### PR DESCRIPTION
NODE_OPTIONS isn't picked up by `/opt/kibana/bin/kibana` because the scoping is local to only the `/etc/init.d/kibana` script without it.
Export it and `/opt/kibana/bin/kibana` picks it up.